### PR TITLE
Update "yle-aws-role" and thus "aws-sdk"

### DIFF
--- a/yle_tf-aws_assume_role.gemspec
+++ b/yle_tf-aws_assume_role.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'yle-aws-role', '~> 1.1'
+  spec.add_dependency 'yle-aws-role', '~> 2.0'
   spec.add_dependency 'yle_tf', '>= 0.1.1'
 
   spec.add_development_dependency 'bundler', '~> 1.13'


### PR DESCRIPTION
Major version upgrade to "yle-aws-role" which pulls in upgrade to the "aws-sdk" version 3.

Upgrade guide if a depending project also depends on aws-sdk:
https://aws.amazon.com/blogs/developer/upgrading-from-version-2-to-version-3-of-the-aws-sdk-for-ruby-2/

If you can't upgrade, you can pin this gem version to `~> 1.0`.