### PR TITLE
README: change account in example config to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Example `tf.yaml` configuration:
 ```yaml
 aws:
   assume_role: true
-  account: 98765432100
+  account: "98765432100"
   role: dev
   duration: 1800
 ```


### PR DESCRIPTION
Numeric account value in tf.yaml results in error:
yle-aws-role-2.0.1/lib/yle/aws/role/accounts.rb:42:in `alias_matcher': undefined method `gsub'