### PR TITLE
Update development dependencies and tested Ruby versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,13 @@
 AllCops:
-    TargetRubyVersion: 2.3
+    TargetRubyVersion: 2.4
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table
+
+Layout/LineLength:
+  Max: 100
+  Severity: warning
 
 Metrics/BlockLength:
   Exclude:
@@ -11,10 +15,6 @@ Metrics/BlockLength:
     - 'spec/**/*'
 
 Metrics/ClassLength:
-  Severity: warning
-
-Metrics/LineLength:
-  Max: 100
   Severity: warning
 
 Metrics/MethodLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - gem install bundler
 
 rvm:
-  - 2.6.0
-  - 2.5.3
-  - 2.4.5
-  - 2.3.8
+  - 2.7.0
+  - 2.6.5
+  - 2.5.7
+  - 2.4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: ruby
 cache: bundler
 
+before_install:
+  # Install Bundler v2 as Travis uses v1.x in Ruby <2.7
+  - gem update --system
+  - gem install bundler
+
 rvm:
   - 2.6.0
   - 2.5.3

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2018 Yleisradio Oy
+Copyright (c) 2016-2020 Yleisradio Oy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/yle_tf-aws_assume_role.gemspec
+++ b/yle_tf-aws_assume_role.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'yle-aws-role', '~> 2.0'
   spec.add_dependency 'yle_tf', '>= 0.1.1'
 
-  spec.add_development_dependency 'bundler', '~> 1.13'
-  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.5'
 end


### PR DESCRIPTION
Add Ruby 2.7 to Travis tests, and drop support for 2.3. Also update development dependencies and Rubocop config.